### PR TITLE
Use local instead of global namespace

### DIFF
--- a/lualib.lua
+++ b/lualib.lua
@@ -1,4 +1,7 @@
+local lualib = {}
 
-function toHex(intValue, numBytes)
+function lualib.toHex(intValue, numBytes)
   return string.format('%0' .. numBytes*2 .. 'X', intValue)
 end
+
+return lualib


### PR DESCRIPTION
A Lua convention is to use the local namespace for (new; there is a deprecated/discouraged approach used in older versions of Lua) libraries and return a dictionary. A script using this library would then do `local lualib = require("lualib")` (or similar) and could then access the library's functions with `lualib.toHex`.